### PR TITLE
Update Remove Windows AI.ps1  to reflect change in file name

### DIFF
--- a/plugins/Remove Windows AI.ps1
+++ b/plugins/Remove Windows AI.ps1
@@ -1,1 +1,1 @@
-﻿iwr https://raw.githubusercontent.com/zoicware/RemoveWindowsAI/main/RemoveAi.ps1 | iex
+﻿iwr https://raw.githubusercontent.com/zoicware/RemoveWindowsAI/refs/heads/main/RemoveWindowsAi.ps1 | iex


### PR DESCRIPTION
The script of Zoicware was renamed to RemoveWindowsAi.ps1.